### PR TITLE
no core dump

### DIFF
--- a/files/chinadns.init
+++ b/files/chinadns.init
@@ -43,9 +43,6 @@ start_instance() {
 	procd_set_param stderr 1
 	procd_set_param nice -5
 	procd_set_param limits nofile="65535 65535"
-	[ -e /proc/sys/kernel/core_pattern ] && {
-		procd_append_param limits core="unlimited"
-	}
 	procd_set_param command /usr/bin/chinadns -m
 	append_parm $1 addr "-b"
 	append_parm $1 port "-p"


### PR DESCRIPTION
上次的 https://github.com/aa65535/openwrt-chinadns/pull/107 添加的，好像不太必要